### PR TITLE
Fix mistake in configuring repository in Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ repositories {
     maven {
         url = uri("https://maven.pkg.github.com/marrek13/kotenberg")
         credentials {
-            username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAMe")
-            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            username = project.findProperty("gpr.user")?.toString() ?: System.getenv("GITHUB_USERNAME")
+            password = project.findProperty("gpr.key")?.toString() ?: System.getenv("GITHUB_TOKEN")
         }
     }
 }


### PR DESCRIPTION
This commit fixes a typo in the configuration of the library repository in the README file that made the code uncompilable.

The fix is simple, and just ensure that the return type from the call is always `String` and not `String?`.

Moreover, this commit fixes a tiny typo that made the username last letter lowercase.


![](https://i.imgflip.com/89mvzo.jpg)
