### PR TITLE
Add Ktor client to library API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ group = "dev.marrek13"
 version = "1.0.0"
 
 dependencies {
-    implementation(libs.ktor.client.core)
+    api(libs.ktor.client.core)
     implementation(libs.ktor.client.cio)
 
     implementation(libs.commons.io)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "kotenberg"


### PR DESCRIPTION
This commit changes the exposure level of the ktor client from `implementation` to `api` so the client of this library can consume the library without failures.

Moreover, it adds the `settings.gradle.kts` file as it's required by Gradle as well to consume the library successfully.


![](https://i.imgflip.com/89mx4g.jpg)
