### PR TITLE
Use default PageProperties in convert functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ val client = Kotenberg("http://localhost:8090/")
 #### URL
 
 ```kotlin
-val response = client.convertUrl("https://gotenberg.dev/", pageProperties)
+val response = client.convertUrl("https://gotenberg.dev/")
 ```
 
 #### HTML
@@ -63,7 +63,7 @@ The only requirement is that one of the files name should be `index.html`.
 ```kotlin
 val index = File("path/to/index.html")
 val header = File("path/to/header.html")
-val response = client.convertHtml(listOf(index, header), pageProperties)
+val response = client.convertHtml(listOf(index, header))
 ```
 
 #### Markdown
@@ -74,7 +74,7 @@ This route accepts an `index.html` file plus markdown files. Check [Gotenberg do
 val index = File("path/to/index.html")
 val markdown = File("path/to/markdown.md")
 
-val response = client.convertMarkdown(listOf(index, markdown), pageProperties)
+val response = client.convertMarkdown(listOf(index, markdown))
 ```
 
 ### Customization
@@ -83,6 +83,7 @@ val response = client.convertMarkdown(listOf(index, markdown), pageProperties)
 
 ```kotlin
 val pageProperties = PageProperties.Builder().build()
+val response = client.convertMarkdown(listOf(index), pageProperties)
 ```
 ### LibreOffice
 `Kotenberg` client provides a `convertWithLibreOffice` method which interacts with [LibreOffice](https://gotenberg.dev/docs/routes#convert-with-libreoffice) to convert different types of documents such as `.docx`, `.epub`, `.eps`, and so on. You can find the list of all file extensions [here](https://gotenberg.dev/docs/routes#office-documents-into-pdfs-route).
@@ -91,7 +92,7 @@ val pageProperties = PageProperties.Builder().build()
 val docx = File("path/to/file.docx")
 val xlsx = File("path/to/file.xlsx")
 
-val response = client.convertWithLibreOffice(listOf(docx, xlsx), pageProperties)
+val response = client.convertWithLibreOffice(listOf(docx, xlsx))
 ```
 
 ### PDF Engines
@@ -116,7 +117,7 @@ Additionally, you can also use `mergeWithPdfEngines` method to [alphabetically](
 val pdf1 = File("path/to/first.pdf")
 val pdf2 = File("path/to/second.pdf")
 
-val response = client.mergeWithPdfEngines(listOf(pdf1, pdf2), pageProperties)
+val response = client.mergeWithPdfEngines(listOf(pdf1, pdf2))
 ```
 ## Example
 

--- a/src/main/kotlin/dev/marrek13/Kotenberg.kt
+++ b/src/main/kotlin/dev/marrek13/Kotenberg.kt
@@ -44,7 +44,7 @@ class Kotenberg(endpoint: String, private val httpClient: HttpClient = HttpClien
      */
     suspend fun convertUrl(
         url: String,
-        pageProperties: PageProperties,
+        pageProperties: PageProperties = PageProperties.Builder().build(),
     ): HttpResponse {
         if (!UrlValidator.isValidURL(url)) {
             throw MalformedURLException()
@@ -66,7 +66,7 @@ class Kotenberg(endpoint: String, private val httpClient: HttpClient = HttpClien
      */
     suspend fun convertHtml(
         files: List<File>,
-        pageProperties: PageProperties,
+        pageProperties: PageProperties = PageProperties.Builder().build(),
     ): HttpResponse =
         files
             .ifEmpty { throw EmptyFileListException() }
@@ -89,7 +89,7 @@ class Kotenberg(endpoint: String, private val httpClient: HttpClient = HttpClien
      */
     suspend fun convertMarkdown(
         files: List<File>,
-        pageProperties: PageProperties,
+        pageProperties: PageProperties = PageProperties.Builder().build(),
     ): HttpResponse =
         files
             .ifEmpty { throw EmptyFileListException() }
@@ -115,7 +115,7 @@ class Kotenberg(endpoint: String, private val httpClient: HttpClient = HttpClien
      */
     suspend fun convertWithLibreOffice(
         files: List<File>,
-        pageProperties: PageProperties,
+        pageProperties: PageProperties = PageProperties.Builder().build(),
     ): HttpResponse =
         files
             .ifEmpty { throw EmptyFileListException() }
@@ -139,7 +139,7 @@ class Kotenberg(endpoint: String, private val httpClient: HttpClient = HttpClien
      */
     suspend fun convertWithPdfEngines(
         files: List<File>,
-        pageProperties: PageProperties,
+        pageProperties: PageProperties = PageProperties.Builder().build(),
     ): HttpResponse = getPdfEnginesHttpResponse(files, pageProperties, PDF_ENGINES_CONVERT_ROUTE)
 
     /**
@@ -152,7 +152,7 @@ class Kotenberg(endpoint: String, private val httpClient: HttpClient = HttpClien
      */
     suspend fun mergeWithPdfEngines(
         files: List<File>,
-        pageProperties: PageProperties,
+        pageProperties: PageProperties = PageProperties.Builder().build(),
     ): HttpResponse =
         getPdfEnginesHttpResponse(
             files = files,

--- a/src/test/kotlin/dev/marrek13/KotenbergTest.kt
+++ b/src/test/kotlin/dev/marrek13/KotenbergTest.kt
@@ -34,7 +34,7 @@ class KotenbergTest {
             val kotenberg = Kotenberg(gotenbergTestContainer.endpoint)
 
             val result =
-                kotenberg.convertUrl(gotenbergTestContainer.endpoint + "/health", PageProperties.Builder().build())
+                kotenberg.convertUrl(gotenbergTestContainer.endpoint + "/health")
 
             assertEquals(200, result.status.value)
             assertEquals("application/pdf", result.headers[HttpHeaders.ContentType])
@@ -51,7 +51,6 @@ class KotenbergTest {
                         File("src/test/resources/html/header.html"),
                         File("src/test/resources/html/footer.html"),
                     ),
-                    PageProperties.Builder().build(),
                 )
             }
         }
@@ -69,7 +68,6 @@ class KotenbergTest {
                         File("src/test/resources/html/footer.html"),
                         File("src/test/resources/html/image.jpg"),
                     ),
-                    PageProperties.Builder().build(),
                 )
 
             assertEquals(200, result.status.value)
@@ -87,7 +85,6 @@ class KotenbergTest {
                         File("src/test/resources/markdown/index.html"),
                         File("src/test/resources/markdown/test.md"),
                     ),
-                    PageProperties.Builder().build(),
                 )
 
             assertEquals(200, result.status.value)
@@ -104,7 +101,6 @@ class KotenbergTest {
                     listOf(
                         File("src/test/resources/libreoffice/test.docx"),
                     ),
-                    PageProperties.Builder().build(),
                 )
 
             assertEquals(200, result.status.value)
@@ -121,7 +117,6 @@ class KotenbergTest {
                     listOf(
                         File("src/test/resources/libreoffice/test.xlsx"),
                     ),
-                    PageProperties.Builder().build(),
                 )
 
             assertEquals(200, result.status.value)
@@ -139,7 +134,6 @@ class KotenbergTest {
                         File("src/test/resources/libreoffice/test.docx"),
                         File("src/test/resources/libreoffice/test.xlsx"),
                     ),
-                    PageProperties.Builder().build(),
                 )
 
             assertEquals(200, result.status.value)


### PR DESCRIPTION
This commit simplifies the usage of the code for users by adding the default `PageProperties` value as default value for each of them. This allows the consumers of the library to use it without the need to pass the `PageProperties.Builder().build()` explicitly unless they do need to configure the conversion.