### PR TITLE
feat: add Maven Central publishing and release workflow secrets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,3 +29,23 @@ jobs:
         run: ./gradlew publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+      # maven-publish uses the OSSRH “Maven-like” PUT API; Central Portal then needs this follow-up
+      # from the same runner IP. See https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
+      - name: Submit build to Central Publisher (Maven Central)
+        if: ${{ secrets.MAVEN_CENTRAL_USERNAME != '' && secrets.MAVEN_CENTRAL_PASSWORD != '' }}
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          set -euo pipefail
+          USER_PASS="${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}"
+          TOKEN=$(echo -n "$USER_PASS" | base64 -w0)
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/dev.marrek13?publishing_type=automatic"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,20 @@
+import org.gradle.api.tasks.javadoc.Javadoc
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.ktfmt)
     id("maven-publish")
+    signing
 }
 
 group = "dev.marrek13"
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.named<Javadoc>("javadoc") { isFailOnError = false }
 
 dependencies {
     api(libs.ktor.client.core)
@@ -25,6 +35,26 @@ repositories { mavenCentral() }
 
 ktfmt { kotlinLangStyle() }
 
+val mavenCentralUsername =
+    System.getenv("MAVEN_CENTRAL_USERNAME") ?: findProperty("mavenCentralUsername")?.toString()
+val mavenCentralPassword =
+    System.getenv("MAVEN_CENTRAL_PASSWORD") ?: findProperty("mavenCentralPassword")?.toString()
+val signingKeyForCentral = System.getenv("SIGNING_KEY") ?: findProperty("signingKey")?.toString()
+
+if (
+    !mavenCentralUsername.isNullOrBlank() &&
+        !mavenCentralPassword.isNullOrBlank() &&
+        signingKeyForCentral.isNullOrBlank()
+) {
+    logger.error(
+        "MAVEN_CENTRAL_USERNAME and MAVEN_CENTRAL_PASSWORD are set but SIGNING_KEY is missing; " +
+            "Maven Central requires signed artifacts."
+    )
+    throw GradleException(
+        "Configure SIGNING_KEY (and SIGNING_PASSWORD if the key is encrypted) for Maven Central."
+    )
+}
+
 publishing {
     publications {
         create<MavenPublication>("maven") {
@@ -33,6 +63,32 @@ publishing {
             version = project.version.toString()
 
             from(components["java"])
+
+            pom {
+                name = "Kotenberg"
+                description.set(
+                    "Type-safe Kotlin client for the Gotenberg document conversion HTTP API."
+                )
+                url.set("https://github.com/marrek13/kotenberg")
+                licenses {
+                    license {
+                        name.set("MIT")
+                        url.set("https://opensource.org/licenses/MIT")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("marrek13")
+                        name.set("Mariusz Sołtysiak")
+                        url.set("https://github.com/marrek13")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/marrek13/kotenberg.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/marrek13/kotenberg.git")
+                    url.set("https://github.com/marrek13/kotenberg")
+                }
+            }
         }
     }
 
@@ -45,5 +101,30 @@ publishing {
                 password = System.getenv("GITHUB_TOKEN")
             }
         }
+        val centralUser = mavenCentralUsername
+        val centralPassword = mavenCentralPassword
+        if (!centralUser.isNullOrBlank() && !centralPassword.isNullOrBlank()) {
+            maven {
+                name = "MavenCentral"
+                url =
+                    uri(
+                        "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/"
+                    )
+                credentials {
+                    username = centralUser
+                    password = centralPassword
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey = signingKeyForCentral
+    val signingPassword =
+        System.getenv("SIGNING_PASSWORD") ?: findProperty("signingPassword")?.toString()
+    if (!signingKey.isNullOrBlank()) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications["maven"])
     }
 }


### PR DESCRIPTION
This pull request updates the Maven Central publishing workflow to support secure and automated deployment. The most important changes are the addition of required secrets and a new step to finalize publication to Maven Central.

Enhancements to Maven Central publishing:

* Added new environment variables for Maven Central credentials and signing keys (`MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `SIGNING_KEY`, `SIGNING_PASSWORD`) to the `publish` job for secure artifact publication.
* Introduced a new workflow step that submits the build to the Central Publisher (Maven Central) using the OSSRH Staging API, ensuring the publication process is completed from the same runner IP.