### PR TITLE
fix: Maven Central uses verified io.github.marrek13 coordinates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,4 +52,4 @@ jobs:
           TOKEN=$(echo -n "$USER_PASS" | base64 -w0)
           curl -fsS -X POST \
             -H "Authorization: Bearer ${TOKEN}" \
-            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/dev.marrek13?publishing_type=automatic"
+            "https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.github.marrek13?publishing_type=automatic"

--- a/README.md
+++ b/README.md
@@ -59,9 +59,31 @@ response.entity.content.use { input ->
 
 ## Installation
 
-Add `Kotenberg` to your project using Gradle or Maven:
+### Maven Central (recommended)
 
-### Gradle Kotlin DSL
+```kotlin
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.github.marrek13:kotenberg:1.0.0")
+}
+```
+
+```xml
+<dependency>
+    <groupId>io.github.marrek13</groupId>
+    <artifactId>kotenberg</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+### GitHub Packages
+
+Coordinates use `dev.marrek13`. Registry requires authentication.
+
+#### Gradle Kotlin DSL
 
 ```kotlin
 repositories {
@@ -79,7 +101,7 @@ dependencies {
 }
 ```
 
-### Maven
+#### Maven
 
 ```xml
 <repository>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.javadoc.Javadoc
 
 plugins {
@@ -35,6 +37,32 @@ repositories { mavenCentral() }
 
 ktfmt { kotlinLangStyle() }
 
+fun MavenPublication.configureKotenbergPom() {
+    pom {
+        name = "Kotenberg"
+        description.set("Type-safe Kotlin client for the Gotenberg document conversion HTTP API.")
+        url.set("https://github.com/marrek13/kotenberg")
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("marrek13")
+                name.set("Mariusz Sołtysiak")
+                url.set("https://github.com/marrek13")
+            }
+        }
+        scm {
+            connection.set("scm:git:https://github.com/marrek13/kotenberg.git")
+            developerConnection.set("scm:git:ssh://git@github.com/marrek13/kotenberg.git")
+            url.set("https://github.com/marrek13/kotenberg")
+        }
+    }
+}
+
 val mavenCentralUsername =
     System.getenv("MAVEN_CENTRAL_USERNAME") ?: findProperty("mavenCentralUsername")?.toString()
 val mavenCentralPassword =
@@ -57,38 +85,19 @@ if (
 
 publishing {
     publications {
-        create<MavenPublication>("maven") {
+        create<MavenPublication>("mavenGithub") {
             groupId = group.toString()
             artifactId = project.name
             version = project.version.toString()
-
             from(components["java"])
-
-            pom {
-                name = "Kotenberg"
-                description.set(
-                    "Type-safe Kotlin client for the Gotenberg document conversion HTTP API."
-                )
-                url.set("https://github.com/marrek13/kotenberg")
-                licenses {
-                    license {
-                        name.set("MIT")
-                        url.set("https://opensource.org/licenses/MIT")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("marrek13")
-                        name.set("Mariusz Sołtysiak")
-                        url.set("https://github.com/marrek13")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:https://github.com/marrek13/kotenberg.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/marrek13/kotenberg.git")
-                    url.set("https://github.com/marrek13/kotenberg")
-                }
-            }
+            configureKotenbergPom()
+        }
+        create<MavenPublication>("mavenCentral") {
+            groupId = "io.github.marrek13"
+            artifactId = project.name
+            version = project.version.toString()
+            from(components["java"])
+            configureKotenbergPom()
         }
     }
 
@@ -119,12 +128,21 @@ publishing {
     }
 }
 
+tasks.withType<PublishToMavenRepository>().configureEach {
+    enabled =
+        when (repository.name) {
+            "GitHubPackages" -> publication.name == "mavenGithub"
+            "MavenCentral" -> publication.name == "mavenCentral"
+            else -> false
+        }
+}
+
 signing {
     val signingKey = signingKeyForCentral
     val signingPassword =
         System.getenv("SIGNING_PASSWORD") ?: findProperty("signingPassword")?.toString()
     if (!signingKey.isNullOrBlank()) {
         useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications["maven"])
+        sign(publishing.publications["mavenCentral"])
     }
 }


### PR DESCRIPTION
## Problem

Publishing to the OSSRH staging API under `dev.marrek13` returned **400 Bad Request** because Maven Central only accepts artifacts under the **verified** namespace (`io.github.marrek13`), while GitHub Packages should keep **`dev.marrek13`**.

## Changes

- Split Gradle publications: **`mavenGithub`** (`dev.marrek13`) → GitHub Packages; **`mavenCentral`** (`io.github.marrek13`) → Central staging (signed).
- Route each publication only to its repository.
- Point the Central Publisher follow-up URL at **`io.github.marrek13`**.
- README: Maven Central first (`io.github.marrek13`), GitHub Packages section unchanged coordinates (`dev.marrek13`).

## Testing

`./gradlew build`

Made with [Cursor](https://cursor.com)